### PR TITLE
Coordination contract fix tests

### DIFF
--- a/crosschain/atomic-swap-ether/README.md
+++ b/crosschain/atomic-swap-ether/README.md
@@ -82,7 +82,7 @@ the expected Sender contract. This authentication information is fetched out of 
 Transaction. The crosschain transaction will not be committed if the Subordinate Transaction
 information is invalid.
 
-# Modifying the Sampe Code
+# Modifying the Sample Code
 ## Solidity Code
 To update the Solidity code:
 * Change the contracts in ./contracts

--- a/crosschain/common-solidity/coordination-contract/README-TRUFFLE.md
+++ b/crosschain/common-solidity/coordination-contract/README-TRUFFLE.md
@@ -13,7 +13,7 @@ npm install -g truffle
 
 # Running the tests:
 Truffle permits writing tests in Javascript or Solidity.  The tests that 
-are currently included are writted in Javascript, which uses the 
+are currently included are written in Javascript, which uses the 
 Mocha framework (https://mochajs.org/) and 
 Chai (http://www.chaijs.com/) for assertions.
 

--- a/crosschain/common-solidity/coordination-contract/contracts/CrosschainCoordinationV1.sol
+++ b/crosschain/common-solidity/coordination-contract/contracts/CrosschainCoordinationV1.sol
@@ -24,7 +24,7 @@ import "./VotingAlgInterface.sol";
  */
 contract CrosschainCoordinationV1 is CrosschainCoordinationInterface {
     // Implementation version of the of the Crosschain Coordination Contract.
-    uint16 constant public VERSION_ONE = 1;
+    uint16 constant private VERSION_ONE = 1;
 
     // The management sidechain is the sidechain with ID 0x00. It is used solely to restrict which
     // users can create a new sidechain. Only members of this sidechain can call addSidechain().

--- a/crosschain/common-solidity/coordination-contract/test/add_one_sidechain.js
+++ b/crosschain/common-solidity/coordination-contract/test/add_one_sidechain.js
@@ -61,10 +61,10 @@ contract('Add One Sidechain', function(accounts) {
         let coordInterface = await await common.getNewCrosschainCoordination();
         await coordInterface.addSidechain(twoSidechainId, await common.getValidVotingContractAddress(), common.VOTING_PERIOD, common.A_VALID_PUBLIC_KEY);
 
-        const isPartBad = await coordInterface.isSidechainParticipant.call(twoSidechainId, accounts[1]);
+        const isPartBad = await coordInterface.isUnmaskedSidechainParticipant.call(twoSidechainId, accounts[1]);
         assert.equal(isPartBad, false, "unexpectedly, account which should not be part of the sidechain is");
 
-        const isPartGood = await coordInterface.isSidechainParticipant.call(twoSidechainId, accounts[0]);
+        const isPartGood = await coordInterface.isUnmaskedSidechainParticipant.call(twoSidechainId, accounts[0]);
         assert.equal(isPartGood, true, "account which should be part of the sidechain is");
     });
 

--- a/crosschain/common-solidity/coordination-contract/test/empty.js
+++ b/crosschain/common-solidity/coordination-contract/test/empty.js
@@ -12,7 +12,7 @@
  */
 
 /**
- * Unitinialised tests. Check that the contract operates
+ * Uninitialised tests. Check that the contract operates
  * correctly when there are no sidechains in the contract - except for the management pseudo-sidechain.
  *
  */
@@ -38,13 +38,13 @@ contract('Empty Tests', function(accounts) {
 
     it("isSidechainParticipant for management pseudo-sidechain: valid participant", async function() {
         let coordInterface = await await common.getDeployedCrosschainCoordination();
-        const isParticipant = await coordInterface.isSidechainParticipant.call(common.MANAGEMENT_PSEUDO_SIDECHAIN_ID, accounts[0]);
+        const isParticipant = await coordInterface.isUnmaskedSidechainParticipant.call(common.MANAGEMENT_PSEUDO_SIDECHAIN_ID, accounts[0]);
         assert.equal(isParticipant, true);
     });
 
     it("isSidechainParticipant for management pseudo-sidechain: non-participant", async function() {
         let coordInterface = await await common.getDeployedCrosschainCoordination();
-        const isParticipant = await coordInterface.isSidechainParticipant.call(common.MANAGEMENT_PSEUDO_SIDECHAIN_ID, accounts[1]);
+        const isParticipant = await coordInterface.isUnmaskedSidechainParticipant.call(common.MANAGEMENT_PSEUDO_SIDECHAIN_ID, accounts[1]);
         assert.equal(isParticipant, false);
     });
 
@@ -71,7 +71,6 @@ contract('Empty Tests', function(accounts) {
     it("getSidechainExists for non-existent sidechain", async function() {
         let coordInterface = await await common.getDeployedCrosschainCoordination();
         const exists = await coordInterface.getSidechainExists.call(NON_EXISTANT_SIDECHAIN);
-
         assert.equal(exists, false);
     });
 
@@ -83,7 +82,7 @@ contract('Empty Tests', function(accounts) {
 
     it("isSidechainParticipant for non-existent sidechain", async function() {
         let coordInterface = await await common.getDeployedCrosschainCoordination();
-        const isParticipant = await coordInterface.isSidechainParticipant.call(NON_EXISTANT_SIDECHAIN, accounts[0]);
+        const isParticipant = await coordInterface.isUnmaskedSidechainParticipant.call(NON_EXISTANT_SIDECHAIN, accounts[0]);
         assert.equal(isParticipant, false);
     });
 

--- a/crosschain/common-solidity/coordination-contract/test/management_pseudo_sidechain.js
+++ b/crosschain/common-solidity/coordination-contract/test/management_pseudo_sidechain.js
@@ -72,7 +72,7 @@ contract('Management Pseduo Sidechain', function(accounts) {
         await common.mineBlocks(parseInt(common.VOTING_PERIOD));
         await coordInterface.actionVotes(common.MANAGEMENT_PSEUDO_SIDECHAIN_ID, secondParticipant);
 
-       let isParticipant = await coordInterface.isSidechainParticipant.call(common.MANAGEMENT_PSEUDO_SIDECHAIN_ID, secondParticipant);
+       let isParticipant = await coordInterface.isUnmaskedSidechainParticipant.call(common.MANAGEMENT_PSEUDO_SIDECHAIN_ID, secondParticipant);
        assert.equal(isParticipant, true, "unexpectedly, Second Participant: isSidechainParticipant == false");
     });
 

--- a/crosschain/common-solidity/coordination-contract/test/unmask.js
+++ b/crosschain/common-solidity/coordination-contract/test/unmask.js
@@ -48,8 +48,8 @@ contract('Unmasking masked participants:', function(accounts) {
         let maskedParticipant  = await addMaskedParticipant(coordInterface, newParticipant, salt1);
 
         // Check that the masked participant exists and the unmasked participant does not exist.
-        let isParticipant = await coordInterface.isSidechainParticipant.call(A_SIDECHAIN_ID, newParticipant);
-        assert.equal(isParticipant, false, "unexpectedly, New masked participant: isSidechainParticipant != false");
+        let isParticipant = await coordInterface.isUnmaskedSidechainParticipant.call(A_SIDECHAIN_ID, newParticipant);
+        assert.equal(isParticipant, false, "unexpectedly, New masked participant: isUnmaskedSidechainParticipant != false");
 
         const EXPECTED_OFFSET = "0";
         let maskedParticipantStored = await coordInterface.getMaskedSidechainParticipant.call(A_SIDECHAIN_ID, EXPECTED_OFFSET);
@@ -60,8 +60,8 @@ contract('Unmasking masked participants:', function(accounts) {
         await coordInterface.unmask(A_SIDECHAIN_ID, EXPECTED_OFFSET, salt, {from: newParticipant});
 
         // Check that the masked participant doesn't exist and the unmasked participant does exist.
-        isParticipant = await coordInterface.isSidechainParticipant.call(A_SIDECHAIN_ID, newParticipant);
-        assert.equal(isParticipant, true, "unexpectedly, unmasked participant doesnt exist: isSidechainParticipant == false");
+        isParticipant = await coordInterface.isUnmaskedSidechainParticipant.call(A_SIDECHAIN_ID, newParticipant);
+        assert.equal(isParticipant, true, "unexpectedly, unmasked participant doesnt exist: isUnmaskedSidechainParticipant == false");
 
         maskedParticipantStored = await coordInterface.getMaskedSidechainParticipant.call(A_SIDECHAIN_ID, EXPECTED_OFFSET);
         maskedParticipantStoredHex = web3.utils.toHex(maskedParticipantStored);

--- a/crosschain/common-solidity/coordination-contract/test/voting_majority.js
+++ b/crosschain/common-solidity/coordination-contract/test/voting_majority.js
@@ -33,8 +33,8 @@ contract('Voting: majority voting tests:', function(accounts) {
         let actionResult = await coordInterface.actionVotes(A_SIDECHAIN_ID, newParticipant);
         const result = await common.checkVotingResult(actionResult.logs);
         assert.equal(true, result, "incorrect result reported in event");
-        let isParticipant = await coordInterface.isSidechainParticipant.call(A_SIDECHAIN_ID, newParticipant);
-        assert.equal(isParticipant, true, "unexpectedly, New Participant: isSidechainParticipant == false");
+        let isParticipant = await coordInterface.isUnmaskedSidechainParticipant.call(A_SIDECHAIN_ID, newParticipant);
+        assert.equal(isParticipant, true, "unexpectedly, New Participant: isUnmaskedSidechainParticipant == false");
     }
     async function addThirdParticipant(coordInterface) {
         let newParticipant = accounts[2];
@@ -44,8 +44,8 @@ contract('Voting: majority voting tests:', function(accounts) {
         let actionResult = await coordInterface.actionVotes(A_SIDECHAIN_ID, newParticipant);
         const result = await common.checkVotingResult(actionResult.logs);
         assert.equal(true, result, "incorrect result reported in event");
-        let isParticipant = await coordInterface.isSidechainParticipant.call(A_SIDECHAIN_ID, newParticipant);
-        assert.equal(isParticipant, true, "unexpectedly, New Participant: isSidechainParticipant == false");
+        let isParticipant = await coordInterface.isUnmaskedSidechainParticipant.call(A_SIDECHAIN_ID, newParticipant);
+        assert.equal(isParticipant, true, "unexpectedly, New Participant: isUnmaskedSidechainParticipant == false");
     }
     async function addFourthParticipant(coordInterface) {
         let newParticipant = accounts[3];
@@ -56,8 +56,8 @@ contract('Voting: majority voting tests:', function(accounts) {
         let actionResult = await coordInterface.actionVotes(A_SIDECHAIN_ID, newParticipant);
         const result = await common.checkVotingResult(actionResult.logs);
         assert.equal(true, result, "incorrect result reported in event");
-        let isParticipant = await coordInterface.isSidechainParticipant.call(A_SIDECHAIN_ID, newParticipant);
-        assert.equal(isParticipant, true, "unexpectedly, New Participant: isSidechainParticipant == false");
+        let isParticipant = await coordInterface.isUnmaskedSidechainParticipant.call(A_SIDECHAIN_ID, newParticipant);
+        assert.equal(isParticipant, true, "unexpectedly, New Participant: isUnmaskedSidechainParticipant == false");
     }
     async function addFifthParticipant(coordInterface) {
         let newParticipant = accounts[4];
@@ -69,8 +69,8 @@ contract('Voting: majority voting tests:', function(accounts) {
         let actionResult = await coordInterface.actionVotes(A_SIDECHAIN_ID, newParticipant);
         const result = await common.checkVotingResult(actionResult.logs);
         assert.equal(true, result, "incorrect result reported in event");
-        let isParticipant = await coordInterface.isSidechainParticipant.call(A_SIDECHAIN_ID, newParticipant);
-        assert.equal(isParticipant, true, "unexpectedly, New Participant: isSidechainParticipant == false");
+        let isParticipant = await coordInterface.isUnmaskedSidechainParticipant.call(A_SIDECHAIN_ID, newParticipant);
+        assert.equal(isParticipant, true, "unexpectedly, New Participant: isUnmaskedSidechainParticipant == false");
     }
 
     it("one participant", async function() {
@@ -98,8 +98,8 @@ contract('Voting: majority voting tests:', function(accounts) {
         let actionResult = await coordInterface.actionVotes(A_SIDECHAIN_ID, newParticipant);
         const result = await common.checkVotingResult(actionResult.logs);
         assert.equal(false, result, "incorrect result reported in event");
-        let isParticipant = await coordInterface.isSidechainParticipant.call(A_SIDECHAIN_ID, newParticipant);
-        assert.equal(isParticipant, false, "Majority did not vote yes. Unexpectedly, New Participant: isSidechainParticipant != false");
+        let isParticipant = await coordInterface.isUnmaskedSidechainParticipant.call(A_SIDECHAIN_ID, newParticipant);
+        assert.equal(isParticipant, false, "Majority did not vote yes. Unexpectedly, New Participant: isUnmaskedSidechainParticipant != false");
     });
 
     it("two participants: one votes yes, one votes no", async function() {
@@ -114,8 +114,8 @@ contract('Voting: majority voting tests:', function(accounts) {
         let actionResult = await coordInterface.actionVotes(A_SIDECHAIN_ID, newParticipant);
         const result = await common.checkVotingResult(actionResult.logs);
         assert.equal(false, result, "incorrect result reported in event");
-        let isParticipant = await coordInterface.isSidechainParticipant.call(A_SIDECHAIN_ID, newParticipant);
-        assert.equal(isParticipant, false, "Majority did not vote yes. Unexpectedly, New Participant: isSidechainParticipant != false");
+        let isParticipant = await coordInterface.isUnmaskedSidechainParticipant.call(A_SIDECHAIN_ID, newParticipant);
+        assert.equal(isParticipant, false, "Majority did not vote yes. Unexpectedly, New Participant: isUnmaskedSidechainParticipant != false");
     });
 
     it("three participants: unanimous vote yes", async function() {
@@ -139,8 +139,8 @@ contract('Voting: majority voting tests:', function(accounts) {
         let actionResult = await coordInterface.actionVotes(A_SIDECHAIN_ID, newParticipant);
         const result = await common.checkVotingResult(actionResult.logs);
         assert.equal(false, result, "incorrect result reported in event");
-        let isParticipant = await coordInterface.isSidechainParticipant.call(A_SIDECHAIN_ID, newParticipant);
-        assert.equal(isParticipant, false, "Majority did not vote yes. Unexpectedly, New Participant: isSidechainParticipant != false");
+        let isParticipant = await coordInterface.isUnmaskedSidechainParticipant.call(A_SIDECHAIN_ID, newParticipant);
+        assert.equal(isParticipant, false, "Majority did not vote yes. Unexpectedly, New Participant: isUnmaskedSidechainParticipant != false");
     });
 
     it("three participants: one votes yes, one votes no", async function() {
@@ -156,8 +156,8 @@ contract('Voting: majority voting tests:', function(accounts) {
         let actionResult = await coordInterface.actionVotes(A_SIDECHAIN_ID, newParticipant);
         const result = await common.checkVotingResult(actionResult.logs);
         assert.equal(false, result, "incorrect result reported in event");
-        let isParticipant = await coordInterface.isSidechainParticipant.call(A_SIDECHAIN_ID, newParticipant);
-        assert.equal(isParticipant, false, "Majority did not vote yes. Unexpectedly, New Participant: isSidechainParticipant != false");
+        let isParticipant = await coordInterface.isUnmaskedSidechainParticipant.call(A_SIDECHAIN_ID, newParticipant);
+        assert.equal(isParticipant, false, "Majority did not vote yes. Unexpectedly, New Participant: isUnmaskedSidechainParticipant != false");
     });
 
     it("three participants: one votes yes, two vote no", async function() {
@@ -174,8 +174,8 @@ contract('Voting: majority voting tests:', function(accounts) {
         let actionResult = await coordInterface.actionVotes(A_SIDECHAIN_ID, newParticipant);
         const result = await common.checkVotingResult(actionResult.logs);
         assert.equal(false, result, "incorrect result reported in event");
-        let isParticipant = await coordInterface.isSidechainParticipant.call(A_SIDECHAIN_ID, newParticipant);
-        assert.equal(isParticipant, false, "Majority did not vote yes. Unexpectedly, New Participant: isSidechainParticipant != false");
+        let isParticipant = await coordInterface.isUnmaskedSidechainParticipant.call(A_SIDECHAIN_ID, newParticipant);
+        assert.equal(isParticipant, false, "Majority did not vote yes. Unexpectedly, New Participant: isUnmaskedSidechainParticipant != false");
     });
 
     it("three participants: two vote yes", async function() {
@@ -191,8 +191,8 @@ contract('Voting: majority voting tests:', function(accounts) {
         let actionResult = await coordInterface.actionVotes(A_SIDECHAIN_ID, newParticipant);
         const result = await common.checkVotingResult(actionResult.logs);
         assert.equal(true, result, "incorrect result reported in event");
-        let isParticipant = await coordInterface.isSidechainParticipant.call(A_SIDECHAIN_ID, newParticipant);
-        assert.equal(isParticipant, true, "Majority voted yes. Unexpectedly, New Participant: isSidechainParticipant == false");
+        let isParticipant = await coordInterface.isUnmaskedSidechainParticipant.call(A_SIDECHAIN_ID, newParticipant);
+        assert.equal(isParticipant, true, "Majority voted yes. Unexpectedly, New Participant: isUnmaskedSidechainParticipant == false");
     });
 
     it("three participants: two vote yes, one votes no", async function() {
@@ -209,8 +209,8 @@ contract('Voting: majority voting tests:', function(accounts) {
         let actionResult = await coordInterface.actionVotes(A_SIDECHAIN_ID, newParticipant);
         const result = await common.checkVotingResult(actionResult.logs);
         assert.equal(true, result, "incorrect result reported in event");
-        let isParticipant = await coordInterface.isSidechainParticipant.call(A_SIDECHAIN_ID, newParticipant);
-        assert.equal(isParticipant, true, "Majority voted yes. Unexpectedly, New Participant: isSidechainParticipant == false");
+        let isParticipant = await coordInterface.isUnmaskedSidechainParticipant.call(A_SIDECHAIN_ID, newParticipant);
+        assert.equal(isParticipant, true, "Majority voted yes. Unexpectedly, New Participant: isUnmaskedSidechainParticipant == false");
     });
 
     it("five participants: three vote yes, one votes no", async function() {
@@ -230,8 +230,8 @@ contract('Voting: majority voting tests:', function(accounts) {
         let actionResult = await coordInterface.actionVotes(A_SIDECHAIN_ID, newParticipant);
         const result = await common.checkVotingResult(actionResult.logs);
         assert.equal(true, result, "incorrect result reported in event");
-        let isParticipant = await coordInterface.isSidechainParticipant.call(A_SIDECHAIN_ID, newParticipant);
-        assert.equal(isParticipant, true, "Majority voted yes. Unexpectedly, New Participant: isSidechainParticipant == false");
+        let isParticipant = await coordInterface.isUnmaskedSidechainParticipant.call(A_SIDECHAIN_ID, newParticipant);
+        assert.equal(isParticipant, true, "Majority voted yes. Unexpectedly, New Participant: isUnmaskedSidechainParticipant == false");
     });
 
 });

--- a/crosschain/common-solidity/coordination-contract/test/voting_timing.js
+++ b/crosschain/common-solidity/coordination-contract/test/voting_timing.js
@@ -28,8 +28,8 @@ contract('Voting: timing tests', function(accounts) {
         const result = await common.checkVotingResult(actionResult.logs);
         assert.equal(true, result, "incorrect result reported in event");
 
-        let isParticipant = await coordInterface.isSidechainParticipant.call(common.MANAGEMENT_PSEUDO_SIDECHAIN_ID, secondParticipant);
-        assert.equal(isParticipant, true, "unexpectedly, Second Participant: isSidechainParticipant == false");
+        let isParticipant = await coordInterface.isUnmaskedSidechainParticipant.call(common.MANAGEMENT_PSEUDO_SIDECHAIN_ID, secondParticipant);
+        assert.equal(isParticipant, true, "unexpectedly, Second Participant: isUnmaskedSidechainParticipant == false");
     });
 
     it("finalise vote after voting period", async function() {
@@ -42,8 +42,8 @@ contract('Voting: timing tests', function(accounts) {
         const result = await common.checkVotingResult(actionResult.logs);
         assert.equal(true, result, "incorrect result reported in event");
 
-        let isParticipant = await coordInterface.isSidechainParticipant.call(common.MANAGEMENT_PSEUDO_SIDECHAIN_ID, secondParticipant);
-        assert.equal(isParticipant, true, "unexpectedly, Second Participant: isSidechainParticipant == false");
+        let isParticipant = await coordInterface.isUnmaskedSidechainParticipant.call(common.MANAGEMENT_PSEUDO_SIDECHAIN_ID, secondParticipant);
+        assert.equal(isParticipant, true, "unexpectedly, Second Participant: isUnmaskedSidechainParticipant == false");
     });
 
     it("finalise vote immediately: expect to fail", async function() {
@@ -61,8 +61,8 @@ contract('Voting: timing tests', function(accounts) {
         }
         assert.equal(didNotTriggerError, false);
 
-        let isParticipant = await coordInterface.isSidechainParticipant.call(common.MANAGEMENT_PSEUDO_SIDECHAIN_ID, secondParticipant);
-        assert.equal(isParticipant, false, "unexpectedly, Second Participant: isSidechainParticipant != false");
+        let isParticipant = await coordInterface.isUnmaskedSidechainParticipant.call(common.MANAGEMENT_PSEUDO_SIDECHAIN_ID, secondParticipant);
+        assert.equal(isParticipant, false, "unexpectedly, Second Participant: isUnmaskedSidechainParticipant != false");
     });
 
     it("dont finalise vote", async function() {
@@ -71,8 +71,8 @@ contract('Voting: timing tests', function(accounts) {
 
         await coordInterface.proposeVote(common.MANAGEMENT_PSEUDO_SIDECHAIN_ID, common.VOTE_ADD_UNMASKED_PARTICIPANT, secondParticipant, "1", "0x0");
 
-        let isParticipant = await coordInterface.isSidechainParticipant.call(common.MANAGEMENT_PSEUDO_SIDECHAIN_ID, secondParticipant);
-        assert.equal(isParticipant, false, "unexpectedly, Second Participant: isSidechainParticipant != false");
+        let isParticipant = await coordInterface.isUnmaskedSidechainParticipant.call(common.MANAGEMENT_PSEUDO_SIDECHAIN_ID, secondParticipant);
+        assert.equal(isParticipant, false, "unexpectedly, Second Participant: isUnmaskedSidechainParticipant != false");
     });
 
     it("finalise vote early: expect to fail", async function() {
@@ -91,8 +91,8 @@ contract('Voting: timing tests', function(accounts) {
         }
         assert.equal(didNotTriggerError, false);
 
-        let isParticipant = await coordInterface.isSidechainParticipant.call(common.MANAGEMENT_PSEUDO_SIDECHAIN_ID, secondParticipant);
-        assert.equal(isParticipant, false, "unexpectedly, Second Participant: isSidechainParticipant != false");
+        let isParticipant = await coordInterface.isUnmaskedSidechainParticipant.call(common.MANAGEMENT_PSEUDO_SIDECHAIN_ID, secondParticipant);
+        assert.equal(isParticipant, false, "unexpectedly, Second Participant: isUnmaskedSidechainParticipant != false");
     });
 
 

--- a/crosschain/common-solidity/coordination-contract/test/voting_types.js
+++ b/crosschain/common-solidity/coordination-contract/test/voting_types.js
@@ -42,8 +42,8 @@ contract('Voting: types of voting / things to vote on:', function(accounts) {
         const result = await common.checkVotingResult(actionResult.logs);
         assert.equal(true, result, "incorrect result reported in event");
 
-        let isParticipant = await coordInterface.isSidechainParticipant.call(A_SIDECHAIN_ID, newParticipant);
-        assert.equal(isParticipant, true, "unexpectedly, New Participant: isSidechainParticipant == false");
+        let isParticipant = await coordInterface.isUnmaskedSidechainParticipant.call(A_SIDECHAIN_ID, newParticipant);
+        assert.equal(isParticipant, true, "unexpectedly, New Participant: isUnmaskedSidechainParticipant == false");
 
         let numUnmaskedParticipant = await coordInterface.getUnmaskedSidechainParticipantsSize.call(A_SIDECHAIN_ID);
         assert.equal(numUnmaskedParticipant, 2, "unexpectedly, number of unmasked participants != 2");
@@ -67,8 +67,8 @@ contract('Voting: types of voting / things to vote on:', function(accounts) {
         assert.equal(true, result, "incorrect result reported in event");
 
         // This code no longer works as the Truffle framework now picks up that maskedParticipant is the wrong size for address.
-        // let isParticipant = await coordInterface.isSidechainParticipant.call(A_SIDECHAIN_ID, maskedParticipant);
-        // assert.equal(isParticipant, false, "unexpectedly, New masked participant: isSidechainParticipant != false");
+        // let isParticipant = await coordInterface.isUnmaskedSidechainParticipant.call(A_SIDECHAIN_ID, maskedParticipant);
+        // assert.equal(isParticipant, false, "unexpectedly, New masked participant: isUnmaskedSidechainParticipant != false");
 
         let numMaskedParticipant = await coordInterface.getMaskedSidechainParticipantsSize.call(A_SIDECHAIN_ID);
         assert.equal(numMaskedParticipant, 1, "unexpectedly, number of masked participants != 1");
@@ -90,8 +90,8 @@ contract('Voting: types of voting / things to vote on:', function(accounts) {
         const result1 = await common.checkVotingResult(actionResults.logs);
         assert.equal(true, result1, "incorrect result reported in event");
 
-        let isParticipant = await coordInterface.isSidechainParticipant.call(A_SIDECHAIN_ID, newParticipant);
-        assert.equal(isParticipant, true, "unexpectedly, New Participant: isSidechainParticipant == false");
+        let isParticipant = await coordInterface.isUnmaskedSidechainParticipant.call(A_SIDECHAIN_ID, newParticipant);
+        assert.equal(isParticipant, true, "unexpectedly, New Participant: isUnmaskedSidechainParticipant == false");
 
         const EXPECTED_OFFSET = "1";
         let newParticipantStored = await coordInterface.getUnmaskedSidechainParticipant.call(A_SIDECHAIN_ID, EXPECTED_OFFSET);
@@ -109,8 +109,8 @@ contract('Voting: types of voting / things to vote on:', function(accounts) {
         const result2 = await common.checkVotingResult(actionResults2.logs);
         assert.equal(true, result2, "incorrect result reported in event");
 
-        isParticipant = await coordInterface.isSidechainParticipant.call(A_SIDECHAIN_ID, participantToRemove);
-        assert.equal(isParticipant, false, "unexpectedly, New Participant: isSidechainParticipant != false");
+        isParticipant = await coordInterface.isUnmaskedSidechainParticipant.call(A_SIDECHAIN_ID, participantToRemove);
+        assert.equal(isParticipant, false, "unexpectedly, New Participant: isUnmaskedSidechainParticipant != false");
 
         let numUnmaskedParticipant = await coordInterface.getUnmaskedSidechainParticipantsSize.call(A_SIDECHAIN_ID);
         assert.equal(numUnmaskedParticipant, 2, "unexpectedly, unmasked participants array size != 2");


### PR DESCRIPTION
Changes to truffle tests in crosschain/common-solidity/test include mainly the renaming of isParticipant to isUnmaskedParticipant, plus a few typo corrections.