### PR TITLE
Enable CircleCI tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,15 +154,15 @@ jobs:
   integrationTests:
     executor: executor_xl
     steps:
-      - prepare
+#      - prepare
       - attach_workspace:
           at: ~/
 
-      - restore_cache:
-          name: Restore cached node dependencies
-          keys:
-            - deps-node-{{ checksum "package-lock.json" }}
-            - deps-node
+#      - restore_cache:
+#          name: Restore cached node dependencies
+#          keys:
+#            - deps-node-{{ checksum "package-lock.json" }}
+#            - deps-node
       - run:
           name: Install Node v10
           # following the official installation instructions
@@ -173,9 +173,9 @@ jobs:
       - run:
           name: Create sidechains
           no_output_timeout: 40m
-          command: |
-            scripts/create_chain.js 11 1
-            scripts/create_chain.js 22 1
+          command: | # parallelize for speed
+            nohup scripts/create_chain.js 11 1 &
+            nohup scripts/create_chain.js 22 1 &
             scripts/create_chain.js 33 1
       - run:
           name: IntegrationTests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,9 +27,9 @@ commands:
           name: Check out Web3j and Besu
           command: |
             git clone https://github.com/PegaSysEng/sidechains-web3j.git ../sidechains-web3j
-            #git --git-dir=../sidechains-web3j/.git rev-parse HEAD > ../sidechains-web3j/headcommit
+            git --git-dir=../sidechains-web3j/.git rev-parse HEAD > ../sidechains-web3j/headcommit
             git clone https://github.com/PegaSysEng/sidechains-besu.git ../sidechains-besu
-            #git --git-dir=../sidechains-besu/.git rev-parse HEAD > ../sidechains-besu/headcommit
+            git --git-dir=../sidechains-besu/.git rev-parse HEAD > ../sidechains-besu/headcommit
             #git rev-parse HEAD > headcommit
 
       - restore_cache:
@@ -41,7 +41,7 @@ commands:
       - restore_cache:
           name: Restore cached Besu build products
           keys:
-            - products-besu-{{ .Revision }}
+            - products-besu-{{ checksum "../sidechains-besu/headcommit" }}
 
       - restore_cache:
           name: Restore cached Web3j gradle dependencies
@@ -55,13 +55,13 @@ commands:
             - deps-samples-{{ checksum "build.gradle" }}
             - deps-samples
 
-#      - restore_cache:
-#          name: Restore gradle build cache
-#          keys: # by decreasing rate of change...
-#            - build-cache-{{ checksum "../sidechains-besu/headcommit" }}-{{ checksum "../sidechains-web3j/headcommit" }}-{{ .Revision }}
-#            - build-cache-{{ checksum "../sidechains-besu/headcommit" }}-{{ checksum "../sidechains-web3j/headcommit" }}
-#            - build-cache-{{ checksum "../sidechains-besu/headcommit" }}
-#            - build-cache
+      - restore_cache:
+          name: Restore gradle build cache
+          keys: # by decreasing rate of change...
+            - build-cache-{{ checksum "../sidechains-besu/headcommit" }}-{{ checksum "../sidechains-web3j/headcommit" }}-{{ .Revision }}
+            - build-cache-{{ checksum "../sidechains-besu/headcommit" }}-{{ checksum "../sidechains-web3j/headcommit" }}
+            - build-cache-{{ checksum "../sidechains-besu/headcommit" }}
+            - build-cache
 
   capture_test_results:
     description: "Capture test results"
@@ -99,7 +99,7 @@ jobs:
             ./gradlew installDist
             popd
             # Build the samples
-            ./gradlew --parallel clean compileJava compileTestJava assemble --stacktrace --info
+            ./gradlew --parallel clean compileJava compileTestJava assemble --stacktrace --info --build-cache
 
       - save_cache:
           name: Caching Besu gradle dependencies
@@ -118,14 +118,14 @@ jobs:
             - .gradle
       - save_cache:
           name: Caching Besu build products
-          key: products-besu-{{ .Revision }}
+          key: products-besu-{{ checksum "../sidechains-besu/headcommit" }}
           paths:
             - ../sidechains-besu/build/
-#      - save_cache:
-#          name: Caching gradle build cache
-#          key: build-cache-{{ .Revision }}-{{ checksum "../sidechains-web3j/headcommit" }}-{{ checksum "../sidechains-besu/headcommit" }}
-#          paths:
-#            - ~/.gradle
+      - save_cache:
+          name: Caching gradle build cache
+          key: build-cache-{{ checksum "../sidechains-besu/headcommit" }}-{{ checksum "../sidechains-web3j/headcommit" }}-{{ .Revision }}
+          paths:
+            - ~/.gradle
       - persist_to_workspace:
           root: ~/
           paths:
@@ -157,12 +157,6 @@ jobs:
 #      - prepare
       - attach_workspace:
           at: ~/
-
-#      - restore_cache:
-#          name: Restore cached node dependencies
-#          keys:
-#            - deps-node-{{ checksum "package-lock.json" }}
-#            - deps-node
       - run:
           name: Install Node v10
           # following the official installation instructions
@@ -186,12 +180,7 @@ jobs:
             nohup scripts/run_node.js 22 0 > node_22_0.out 2> node_22_0.err &
             nohup scripts/run_node.js 33 0 > node_33_0.out 2> node_33_0.err &
             # Run the tests proper
-            ./gradlew --parallel integrationTest --stacktrace --info
-#      - save_cache:
-#          name: Caching Node deps
-#          key: deps-node-{{ checksum "package-lock.json" }}
-#          paths:
-#            - ./node_modules
+            ./gradlew --parallel integrationTest --stacktrace --info --build-cache
       - capture_test_results
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,14 +92,10 @@ jobs:
           command: |
             pushd .
             # Build our Web3j
-            cd ..
-            git clone https://github.com/PegaSysEng/sidechains-web3j.git
-            cd sidechains-web3j
+            cd ../sidechains-web3j
             ./gradlew installDist
             # Build our Besu
-            cd ..
-            git clone https://github.com/PegaSysEng/sidechains-besu.git
-            cd sidechains-besu
+            cd ../sidechains-besu
             ./gradlew installDist
             popd
             # Build the samples

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,10 +27,10 @@ commands:
           name: Check out Web3j and Besu
           command: |
             git clone https://github.com/PegaSysEng/sidechains-web3j.git ../sidechains-web3j
-            git --git-dir=../sidechains-web3j/.git rev-parse HEAD > ../sidechains-web3j/headcommit
+#            git --git-dir=../sidechains-web3j/.git rev-parse HEAD > ../sidechains-web3j/headcommit
             git clone https://github.com/PegaSysEng/sidechains-besu.git ../sidechains-besu
-            git --git-dir=../sidechains-besu/.git rev-parse HEAD > ../sidechains-besu/headcommit
-            git rev-parse HEAD > headcommit
+#            git --git-dir=../sidechains-besu/.git rev-parse HEAD > ../sidechains-besu/headcommit
+#            git rev-parse HEAD > headcommit
 
       - restore_cache:
           name: Restore cached Besu gradle dependencies
@@ -55,13 +55,13 @@ commands:
             - deps-samples-{{ checksum "build.gradle" }}
             - deps-samples
 
-      - restore_cache:
-          name: Restore gradle build cache
-          keys: # by decreasing rate of change...
-            - build-cache-{{ checksum "../sidechains-besu/headcommit" }}-{{ checksum "../sidechains-web3j/headcommit" }}-{{ .Revision }}
-            - build-cache-{{ checksum "../sidechains-besu/headcommit" }}-{{ checksum "../sidechains-web3j/headcommit" }}
-            - build-cache-{{ checksum "../sidechains-besu/headcommit" }}
-            - build-cache
+#      - restore_cache:
+#          name: Restore gradle build cache
+#          keys: # by decreasing rate of change...
+#            - build-cache-{{ checksum "../sidechains-besu/headcommit" }}-{{ checksum "../sidechains-web3j/headcommit" }}-{{ .Revision }}
+#            - build-cache-{{ checksum "../sidechains-besu/headcommit" }}-{{ checksum "../sidechains-web3j/headcommit" }}
+#            - build-cache-{{ checksum "../sidechains-besu/headcommit" }}
+#            - build-cache
 
   capture_test_results:
     description: "Capture test results"
@@ -121,11 +121,11 @@ jobs:
           key: products-besu-{{ .Revision }}
           paths:
             - ../sidechains-besu/build/
-      - save_cache:
-          name: Caching gradle build cache
-          key: build-cache-{{ .Revision }}-{{ checksum "../sidechains-web3j/headcommit" }}-{{ checksum "../sidechains-besu/headcommit" }}
-          paths:
-            - ~/.gradle
+#      - save_cache:
+#          name: Caching gradle build cache
+#          key: build-cache-{{ .Revision }}-{{ checksum "../sidechains-web3j/headcommit" }}-{{ checksum "../sidechains-besu/headcommit" }}
+#          paths:
+#            - ~/.gradle
       - persist_to_workspace:
           root: ~/
           paths:
@@ -173,9 +173,9 @@ jobs:
       - run:
           name: Create sidechains
           no_output_timeout: 40m
-          command: | # parallelize for speed
-            nohup scripts/create_chain.js 11 1 &
-            nohup scripts/create_chain.js 22 1 &
+          command: |
+            scripts/create_chain.js 11 1
+            scripts/create_chain.js 22 1
             scripts/create_chain.js 33 1
       - run:
           name: IntegrationTests
@@ -187,11 +187,11 @@ jobs:
             nohup scripts/run_node.js 33 0 > node_33_0.out 2> node_33_0.err &
             # Run the tests proper
             ./gradlew --parallel integrationTest --stacktrace --info
-      - save_cache:
-          name: Caching Node deps
-          key: deps-node-{{ checksum "package-lock.json" }}
-          paths:
-            - ./node_modules
+#      - save_cache:
+#          name: Caching Node deps
+#          key: deps-node-{{ checksum "package-lock.json" }}
+#          paths:
+#            - ./node_modules
       - capture_test_results
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,12 +23,21 @@ commands:
     description: "Prepare"
     steps:
       - checkout
-      - restore_cache:
-          name: Restore cached gradle dependencies
-          keys:
-            - deps-{{ checksum "build.gradle" }}-{{ .Branch }}-{{ .Revision }}
-            - deps-{{ checksum "build.gradle" }}
-            - deps-
+      - run:
+          name: Install Packages - Node v10
+          # following the official installation instructions
+          command: |
+            curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
+            sudo apt-get install -y nodejs
+            npm install scripts
+
+#      # caching in CircleCI is messy. Disabling until we decide on what needs to be cached + is worth the effort + how to reliably detect it changed
+#      - restore_cache:
+#          name: Restore cached gradle dependencies
+#          keys:
+#            - deps-{{ checksum "../sidechains-besu/gradle/versions.gradle" + DEPENDENCY VERSIONS OF OTHER PROJS}}-{{ .Branch }}-{{ .Revision }}
+#            - deps-{{ checksum "../sidechains-besu/gradle/versions.gradle" }}
+#            - deps-
 
   capture_test_results:
     description: "Capture test results"
@@ -63,20 +72,24 @@ jobs:
             cd sidechains-web3j
             ./gradlew installDist
             # Build our Besu
-            #cd ..
-            #git clone https://github.com/PegaSysEng/sidechains-besu.git
-            #cd sidechains-besu
-            #./gradlew installDist
-            # Create sidechains and run them
-            # ...
+            cd ..
+            git clone https://github.com/PegaSysEng/sidechains-besu.git
+            cd sidechains-besu
+            ./gradlew installDist
             popd
-            ./gradlew --parallel clean compileJava compileTestJava assemble
-      - save_cache:
-          name: Caching gradle dependencies
-          key: deps-{{ checksum "build.gradle" }}-{{ .Branch }}-{{ .Revision }}
-          paths:
-            - .gradle
-            - ~/.gradle
+            # Create sidechains and run them
+            scripts/create_chain.js 11 1
+            scripts/create_chain.js 22 1
+            scripts/create_chain.js 33 1
+            ./gradlew --parallel clean compileJava compileTestJava assemble --stacktrace --info
+ #     - save_cache:
+ #         name: Caching gradle dependencies
+ #         key: deps-{{ checksum "build.gradle" }}-{{ .Branch }}-{{ .Revision }}
+ #         paths:
+ #           - .gradle
+ #           - ../sidechains-web3j/.gradle
+ #           - ../sidechains-besu/.gradle
+ #           - ~/.gradle # includes build cache
       - persist_to_workspace:
           root: ~/project
           paths:
@@ -100,12 +113,26 @@ jobs:
             ./gradlew --parallel build
       - capture_test_results
 
+  integrationTests:
+    executor: besu_executor_xl
+    steps:
+      - prepare
+      - attach_workspace:
+          at: ~/project
+      - run:
+          name: IntegrationTests
+          no_output_timeout: 40m
+          command: |
+            ./gradlew --parallel integrationTest --stacktrace --info
+      - capture_test_results
 
 workflows:
   version: 2
   default:
     jobs:
       - assemble
-
+      - integrationTests:
+          requires:
+            - assemble
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 ---
 version: 2.1
 executors:
-  web3j_executor_med: # 2cpu, 4G ram
+  executor_med: # 2cpu, 4G ram
     docker:
       - image: circleci/openjdk:11.0.4-jdk-stretch
     resource_class: medium
@@ -9,7 +9,7 @@ executors:
     environment:
       GRADLE_OPTS: -Xmx2048m -Dorg.gradle.daemon=false -Dorg.gradle.parallel=true -Dorg.gradle.workers.max=2
 
-  web3j_executor_xl: # 8cpu, 16G ram
+  executor_xl: # 8cpu, 16G ram
     docker:
       - image: circleci/openjdk:11.0.4-jdk-stretch
     resource_class: xlarge
@@ -59,7 +59,7 @@ commands:
 
 jobs:
   assemble:
-    executor: web3j_executor_xl
+    executor: executor_xl
     steps:
       - prepare
       - run:
@@ -101,7 +101,7 @@ jobs:
           when: always
 
   unitTests:
-    executor: web3j_executor_xl
+    executor: executor_xl
     steps:
       - prepare
       - attach_workspace:
@@ -114,7 +114,7 @@ jobs:
       - capture_test_results
 
   integrationTests:
-    executor: besu_executor_xl
+    executor: executor_xl
     steps:
       - prepare
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,13 +93,13 @@ jobs:
             pushd .
             # Build our Web3j
             cd ../sidechains-web3j
-            ./gradlew installDist
+            ./gradlew --parallel --stacktrace --info --build-cache installDist
             # Build our Besu
             cd ../sidechains-besu
-            ./gradlew installDist
+            ./gradlew --parallel --stacktrace --info --build-cache installDist
             popd
             # Build the samples
-            ./gradlew --parallel clean compileJava compileTestJava assemble --stacktrace --info --build-cache
+            ./gradlew --parallel --stacktrace --info --build-cache clean compileJava compileTestJava assemble
 
       - save_cache:
           name: Caching Besu gradle dependencies
@@ -171,6 +171,11 @@ jobs:
             scripts/create_chain.js 11 1
             scripts/create_chain.js 22 1
             scripts/create_chain.js 33 1
+      - restore_cache:
+          name: Restore cached Samples gradle dependencies
+          keys:
+            - deps-samples-{{ checksum "build.gradle" }}
+            - deps-samples
       - run:
           name: IntegrationTests
           no_output_timeout: 40m
@@ -180,7 +185,7 @@ jobs:
             nohup scripts/run_node.js 22 0 > node_22_0.out 2> node_22_0.err &
             nohup scripts/run_node.js 33 0 > node_33_0.out 2> node_33_0.err &
             # Run the tests proper
-            ./gradlew --parallel integrationTest --stacktrace --info --build-cache
+            ./gradlew --parallel --stacktrace --info --build-cache integrationTest
       - capture_test_results
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,6 +100,7 @@ jobs:
             popd
             # Build the samples
             ./gradlew --parallel clean compileJava compileTestJava assemble --stacktrace --info
+
       - save_cache:
           name: Caching Besu gradle dependencies
           key: deps-besu-{{ checksum "../sidechains-besu/gradle/versions.gradle" }}
@@ -156,26 +157,41 @@ jobs:
       - prepare
       - attach_workspace:
           at: ~/
+
+      - restore_cache:
+          name: Restore cached node dependencies
+          keys:
+            - deps-node-{{ checksum "package-lock.json" }}
+            - deps-node
       - run:
-          name: Install Packages - Node v10
+          name: Install Node v10
           # following the official installation instructions
           command: |
             curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
             sudo apt-get install -y nodejs
             npm install scripts
       - run:
-          name: IntegrationTests
+          name: Create sidechains
           no_output_timeout: 40m
           command: |
-            # Create sidechains
             scripts/create_chain.js 11 1
             scripts/create_chain.js 22 1
             scripts/create_chain.js 33 1
-            # Run them
+      - run:
+          name: IntegrationTests
+          no_output_timeout: 40m
+          command: |
+            # Run the sidechains
             nohup scripts/run_node.js 11 0 > node_11_0.out 2> node_11_0.err &
             nohup scripts/run_node.js 22 0 > node_22_0.out 2> node_22_0.err &
             nohup scripts/run_node.js 33 0 > node_33_0.out 2> node_33_0.err &
+            # Run the tests proper
             ./gradlew --parallel integrationTest --stacktrace --info
+      - save_cache:
+          name: Caching Node deps
+          key: deps-node-{{ checksum "package-lock.json" }}
+          paths:
+            - ./node_modules
       - capture_test_results
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,9 +91,11 @@ jobs:
  #           - ../sidechains-besu/.gradle
  #           - ~/.gradle # includes build cache
       - persist_to_workspace:
-          root: ~/project
+          root: ~
           paths:
-            - ./
+            - project
+            - sidechains-web3j
+            - sidechains-besu
       - store_artifacts:
           name: Distribution artifacts
           path:  build/distributions
@@ -118,7 +120,7 @@ jobs:
     steps:
       - prepare
       - attach_workspace:
-          at: ~/project
+          at: ~
       - run:
           name: IntegrationTests
           no_output_timeout: 40m

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,7 @@ commands:
               mkdir -p "$TARGET"
               cp -rf ${FILE}/*/* "$TARGET"
             done
+            cp node_*.* "$TARGET"
       - store_test_results:
           path: build/test-results
 
@@ -77,10 +78,7 @@ jobs:
             cd sidechains-besu
             ./gradlew installDist
             popd
-            # Create sidechains and run them
-            scripts/create_chain.js 11 1
-            scripts/create_chain.js 22 1
-            scripts/create_chain.js 33 1
+            # Build the samples
             ./gradlew --parallel clean compileJava compileTestJava assemble --stacktrace --info
  #     - save_cache:
  #         name: Caching gradle dependencies
@@ -125,6 +123,14 @@ jobs:
           name: IntegrationTests
           no_output_timeout: 40m
           command: |
+            # Create sidechains
+            scripts/create_chain.js 11 1
+            scripts/create_chain.js 22 1
+            scripts/create_chain.js 33 1
+            # Run them
+            nohup scripts/run_node.js 11 0 > node_11_0.out 2> node_11_0.err &
+            nohup scripts/run_node.js 22 0 > node_22_0.out 2> node_22_0.err &
+            nohup scripts/run_node.js 33 0 > node_33_0.out 2> node_33_0.err &
             ./gradlew --parallel integrationTest --stacktrace --info
       - capture_test_results
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,11 +91,11 @@ jobs:
  #           - ../sidechains-besu/.gradle
  #           - ~/.gradle # includes build cache
       - persist_to_workspace:
-          root: ~
+          root: ~/
           paths:
-            - project
-            - sidechains-web3j
-            - sidechains-besu
+            - ./project
+            - ./sidechains-web3j
+            - ./sidechains-besu
       - store_artifacts:
           name: Distribution artifacts
           path:  build/distributions
@@ -120,7 +120,7 @@ jobs:
     steps:
       - prepare
       - attach_workspace:
-          at: ~
+          at: ~/
       - run:
           name: IntegrationTests
           no_output_timeout: 40m

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,10 +27,10 @@ commands:
           name: Check out Web3j and Besu
           command: |
             git clone https://github.com/PegaSysEng/sidechains-web3j.git ../sidechains-web3j
-#            git --git-dir=../sidechains-web3j/.git rev-parse HEAD > ../sidechains-web3j/headcommit
+            #git --git-dir=../sidechains-web3j/.git rev-parse HEAD > ../sidechains-web3j/headcommit
             git clone https://github.com/PegaSysEng/sidechains-besu.git ../sidechains-besu
-#            git --git-dir=../sidechains-besu/.git rev-parse HEAD > ../sidechains-besu/headcommit
-#            git rev-parse HEAD > headcommit
+            #git --git-dir=../sidechains-besu/.git rev-parse HEAD > ../sidechains-besu/headcommit
+            #git rev-parse HEAD > headcommit
 
       - restore_cache:
           name: Restore cached Besu gradle dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,20 +24,44 @@ commands:
     steps:
       - checkout
       - run:
-          name: Install Packages - Node v10
-          # following the official installation instructions
+          name: Check out Web3j and Besu
           command: |
-            curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
-            sudo apt-get install -y nodejs
-            npm install scripts
+            git clone https://github.com/PegaSysEng/sidechains-web3j.git ../sidechains-web3j
+            git --git-dir=../sidechains-web3j/.git rev-parse HEAD > ../sidechains-web3j/headcommit
+            git clone https://github.com/PegaSysEng/sidechains-besu.git ../sidechains-besu
+            git --git-dir=../sidechains-besu/.git rev-parse HEAD > ../sidechains-besu/headcommit
+            git rev-parse HEAD > headcommit
 
-#      # caching in CircleCI is messy. Disabling until we decide on what needs to be cached + is worth the effort + how to reliably detect it changed
-#      - restore_cache:
-#          name: Restore cached gradle dependencies
-#          keys:
-#            - deps-{{ checksum "../sidechains-besu/gradle/versions.gradle" + DEPENDENCY VERSIONS OF OTHER PROJS}}-{{ .Branch }}-{{ .Revision }}
-#            - deps-{{ checksum "../sidechains-besu/gradle/versions.gradle" }}
-#            - deps-
+      - restore_cache:
+          name: Restore cached Besu gradle dependencies
+          keys:
+            - deps-besu-{{ checksum "../sidechains-besu/gradle/versions.gradle" }}
+            - deps-besu
+
+      - restore_cache:
+          name: Restore cached Besu build products
+          keys:
+            - products-besu-{{ .Revision }}
+
+      - restore_cache:
+          name: Restore cached Web3j gradle dependencies
+          keys:
+            - deps-web3j-{{ checksum "../sidechains-web3j/build.gradle" }}
+            - deps-web3j
+
+      - restore_cache:
+          name: Restore cached Samples gradle dependencies
+          keys:
+            - deps-samples-{{ checksum "build.gradle" }}
+            - deps-samples
+
+      - restore_cache:
+          name: Restore gradle build cache
+          keys: # by decreasing rate of change...
+            - build-cache-{{ checksum "../sidechains-besu/headcommit" }}-{{ checksum "../sidechains-web3j/headcommit" }}-{{ .Revision }}
+            - build-cache-{{ checksum "../sidechains-besu/headcommit" }}-{{ checksum "../sidechains-web3j/headcommit" }}
+            - build-cache-{{ checksum "../sidechains-besu/headcommit" }}
+            - build-cache
 
   capture_test_results:
     description: "Capture test results"
@@ -80,20 +104,37 @@ jobs:
             popd
             # Build the samples
             ./gradlew --parallel clean compileJava compileTestJava assemble --stacktrace --info
- #     - save_cache:
- #         name: Caching gradle dependencies
- #         key: deps-{{ checksum "build.gradle" }}-{{ .Branch }}-{{ .Revision }}
- #         paths:
- #           - .gradle
- #           - ../sidechains-web3j/.gradle
- #           - ../sidechains-besu/.gradle
- #           - ~/.gradle # includes build cache
+      - save_cache:
+          name: Caching Besu gradle dependencies
+          key: deps-besu-{{ checksum "../sidechains-besu/gradle/versions.gradle" }}
+          paths:
+            - ../sidechains-besu/.gradle
+      - save_cache:
+          name: Caching Web3j gradle dependencies
+          key: deps-web3j-{{ checksum "../sidechains-web3j/build.gradle" }}
+          paths:
+            - ../sidechains-web3j/.gradle
+      - save_cache:
+          name: Caching Samples gradle dependencies
+          key: deps-samples-{{ checksum "build.gradle" }}
+          paths:
+            - .gradle
+      - save_cache:
+          name: Caching Besu build products
+          key: products-besu-{{ .Revision }}
+          paths:
+            - ../sidechains-besu/build/
+      - save_cache:
+          name: Caching gradle build cache
+          key: build-cache-{{ .Revision }}-{{ checksum "../sidechains-web3j/headcommit" }}-{{ checksum "../sidechains-besu/headcommit" }}
+          paths:
+            - ~/.gradle
       - persist_to_workspace:
           root: ~/
           paths:
             - ./project
             - ./sidechains-web3j
-            - ./sidechains-besu
+            - ./sidechains-besu/build/install
       - store_artifacts:
           name: Distribution artifacts
           path:  build/distributions
@@ -119,6 +160,13 @@ jobs:
       - prepare
       - attach_workspace:
           at: ~/
+      - run:
+          name: Install Packages - Node v10
+          # following the official installation instructions
+          command: |
+            curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
+            sudo apt-get install -y nodejs
+            npm install scripts
       - run:
           name: IntegrationTests
           no_output_timeout: 40m

--- a/scripts/run_multichain.sh
+++ b/scripts/run_multichain.sh
@@ -30,8 +30,9 @@ do
     if (( $IS_FIRST == 1))
     then
       IS_FIRST=0
-      tmux start-server \; set -g remain-on-exit on
       tmux new-session -s multichain -d "bash -c \"echo $STANDOUT Running '$FULL_CMD_LINE' $OFFSTANDOUT ; $FULL_CMD_LINE\""
+      tmux set -g remain-on-exit on
+      tmux setw remain-on-exit on
       tmux bind-key -n Escape kill-session
       tmux set -g mouse on
     else

--- a/testall/build.gradle
+++ b/testall/build.gradle
@@ -1,3 +1,4 @@
+import java.time.LocalTime
 
 dependencies {
     compile project(':crosschain-atomic-swap-ether')
@@ -14,10 +15,18 @@ dependencies {
     testImplementation group: 'junit', name: 'junit', version: '4.12'
 }
 
-// when a test fails, show its stacktrace in stdout
-test {
+test.enabled = false
+
+task integrationTest(type: Test) {
+    inputs.property "integration.date", LocalTime.now() // so it runs every time
+
+    description = 'Runs tests integrating sidechains-besu, sidechains-web3j and crosschain samples'
+
     testLogging {
         exceptionFormat = 'full'
         showStackTraces = true
+        //showStandardStreams = true
+        showExceptions = true
+        showCauses = true
     }
 }


### PR DESCRIPTION
Creates an integrationTest task that unconditionally runs when invoked with `./gradlew integrationTest`, and does NOT run as part of a normal build.
Enables the integration test to run on CircleCI.